### PR TITLE
Using sys.executable instead of hardcoded text "python".

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import os.path
 import platform
 import re
 import subprocess
+import sys
 
 try:
     from setuptools import setup, find_packages
@@ -121,7 +122,7 @@ class build_py(_build_py):
         )
         try:
             script_str = ctypesgen_dist.get_metadata('scripts/ctypesgen.py')
-            ctypesgen_command = ["python", "-", "--cpp", self.ctypesgen_cpp]
+            ctypesgen_command = [sys.executable, "-", "--cpp", self.ctypesgen_cpp]
         except:
             script_str = None
             ctypesgen_command = ["ctypesgen.py", "--cpp", self.ctypesgen_cpp]


### PR DESCRIPTION
It's better to use sys.executable instead of hardcoded text "python" in case you want to use a non default python interpreter like python2.7.
