### PR TITLE
Python 3 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@ python-gssapi
 
 Attempt at an object-oriented interface to GSSAPI for Python.
 This project is licensed under the terms of the MIT license (see LICENSE.txt).
+
+
+Python3 Support
+---------------
+Python-gssapi is able to run on Python3, but to install it you can't use the setup script right now,
+because the ctypesgen module used to build the gssapi_h module is not able to run on Python3 and it
+generates just Python2 code.
+So to install python-gssapi on Python3 follow these steps:
+- Build python-gssapi on Python2.
+- Look for the generated gssapi_h module in your/build/directory/lib/gssapi/headers/ and use 2to3 to port it to py3.
+- Move the converted gssapi_h module into gssapi/source/folder/headers/.
+- Finally move the gssapi source folder to /path/to/your/python/installation/lib/python3.x/site-packages/.

--- a/gssapi/error.py
+++ b/gssapi/error.py
@@ -55,7 +55,7 @@ def status_list(maj_status, min_status, status_type=GSS_C_GSS_CODE, mech_type=GS
                 byref(status_buf)
             )
             if retval == GSS_S_COMPLETE:
-                statuses.append("({0}) {1}.".format(maj_status, string_at(status_buf.value, status_buf.length)))
+                statuses.append("({0}) {1}.".format(maj_status, string_at(status_buf.value, status_buf.length).decode()))
             elif retval == GSS_S_BAD_MECH:
                 statuses.append("Unsupported mechanism type passed to GSSException")
             elif retval == GSS_S_BAD_STATUS:
@@ -75,7 +75,7 @@ def status_list(maj_status, min_status, status_type=GSS_C_GSS_CODE, mech_type=GS
 
 
 def _status_to_str(maj_status, min_status, mech_type=GSS_C_NO_OID):
-    return b' '.join(status_list(maj_status, min_status, mech_type=mech_type))
+    return ' '.join(status_list(maj_status, min_status, mech_type=mech_type))
 
 
 class GSSException(Exception):

--- a/gssapi/names.py
+++ b/gssapi/names.py
@@ -44,7 +44,6 @@ class Name(object):
         :const:`gssapi.C_NT_USER_NAME` or :const:`gssapi.C_NT_HOSTBASED_SERVICE`.
     :type name_type: `gssapi.C_NT_*` constant or :class:`~gssapi.oids.OID`
     """
-    __metaclass__ = _NameMeta
 
     def __init__(self, name, name_type=GSS_C_NO_OID):
         super(Name, self).__init__()
@@ -61,9 +60,9 @@ class Name(object):
         minor_status = OM_uint32()
 
         name_buffer = gss_buffer_desc()
-        if isinstance(name, basestring):
+        if isinstance(name, str):
             name_buffer.length = len(name)
-            name_buffer.value = cast(c_char_p(name), c_void_p)
+            name_buffer.value = cast(c_char_p(str.encode(name)), c_void_p)
         elif isinstance(name, numbers.Integral):
             c_name = uid_t(name)
             name_buffer.length = sizeof(c_name)
@@ -86,8 +85,7 @@ class Name(object):
             raise GSSCException(retval, minor_status)
 
     def __str__(self):
-        return self._display()
-
+        return self._display().decode()
     @property
     def type(self):
         """

--- a/gssapi/oids.py
+++ b/gssapi/oids.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 
 import re
+import sys
 from ctypes import byref, c_int, string_at, cast
-
+import struct
 from pyasn1.codec.ber import decoder
 
 from .headers.gssapi_h import (
@@ -54,7 +55,10 @@ class OID(object):
     def __hash__(self):
         hsh = 31
         for c in string_at(self._oid.elements, self._oid.length):
-            hsh = 101 * hsh + ord(c)
+            if sys.version_info >= (3,):
+                hsh = 101 * hsh + c
+            else:
+                hsh = 101 * hsh + ord(c)
         return hsh
 
     @staticmethod
@@ -86,7 +90,7 @@ class OID(object):
 
     def __str__(self):
         tag = b'\x06'
-        length = chr(self._oid.length)
+        length = struct.pack('B', self._oid.length)
         value = string_at(self._oid.elements, self._oid.length)
         return str(decoder.decode(tag + length + value)[0])
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def _strip_unknown_cflags(cflags):
 
 
 def _find_gssapi_h(cflags):
-    gcc_target = subprocess.check_output(["gcc", "-dumpmachine"])
+    gcc_target = subprocess.check_output(["gcc", "-dumpmachine"]).strip()
     default_paths = [
         "/usr/local/include",
         "/usr/{target}/include".format(target=gcc_target),
@@ -90,6 +90,8 @@ def _finalize_options(self):
             except:
                 config_compile_flags = []
                 config_link_flags = []
+        config_compile_flags = [ f.decode() for f in config_compile_flags ]
+        config_link_flags = [ f.decode() for f in config_link_flags ]
         self.compile_flags = (_strip_unknown_cflags(config_compile_flags)
                               + _strip_unknown_cflags(config_link_flags))
         self.cpp_extra_flags = tuple(config_compile_flags)

--- a/tests/names.py
+++ b/tests/names.py
@@ -111,27 +111,27 @@ class KerberosNameTest(NameTest):
 
     def test_export(self):
         name1exp = Name("spam").canonicalize(self.krb5mech).export()
-        self.assertIsInstance(name1exp, str)
+        self.assertIsInstance(name1exp, bytes)
         self.assertGreater(len(name1exp), 0)
 
         user_name_exp = Name(self.user, C_NT_USER_NAME).canonicalize(self.krb5mech).export()
-        self.assertIsInstance(user_name_exp, str)
+        self.assertIsInstance(user_name_exp, bytes)
         self.assertGreater(len(user_name_exp), 0)
 
         svc_name_exp = Name("host@example.com", C_NT_HOSTBASED_SERVICE).canonicalize(self.krb5mech).export()
-        self.assertIsInstance(svc_name_exp, str)
+        self.assertIsInstance(svc_name_exp, bytes)
         self.assertGreater(len(svc_name_exp), 0)
 
         bare_svc_name_exp = Name("HTTP", C_NT_HOSTBASED_SERVICE).canonicalize(self.krb5mech).export()
-        self.assertIsInstance(bare_svc_name_exp, str)
+        self.assertIsInstance(bare_svc_name_exp, bytes)
         self.assertGreater(len(bare_svc_name_exp), 0)
         if not self.is_heimdal_mac:
             str_uid_name_exp = Name(str(self.uid), C_NT_STRING_UID_NAME).canonicalize(self.krb5mech).export()
-            self.assertIsInstance(str_uid_name_exp, str)
+            self.assertIsInstance(str_uid_name_exp, bytes)
             self.assertGreater(len(str_uid_name_exp), 0)
 
             machine_uid_name_exp = Name(self.uid, C_NT_MACHINE_UID_NAME).canonicalize(self.krb5mech).export()
-            self.assertIsInstance(machine_uid_name_exp, str)
+            self.assertIsInstance(machine_uid_name_exp, bytes)
             self.assertGreater(len(machine_uid_name_exp), 0)
 
     @patch('gssapi.names.gss_import_name', wraps=gssapi_h.gss_import_name)

--- a/tests/oids.py
+++ b/tests/oids.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import unittest
+import sys
 from ctypes import byref
 
 from mock import patch
@@ -101,8 +102,12 @@ class OIDSetTest(unittest.TestCase):
 
     def test_array_access(self):
         all_mechs = get_all_mechs()
-        for x in xrange(len(all_mechs)):
-            assert all_mechs[x] in all_mechs
+        if sys.version_info < (3,):
+            for x in xrange(len(all_mechs)):
+                assert all_mechs[x] in all_mechs
+        else:
+            for x in range(len(all_mechs)):
+                assert all_mechs[x] in all_mechs
         self.assertRaises(IndexError, lambda n: all_mechs[n], -(len(all_mechs) + 1))
         self.assertRaises(IndexError, lambda n: all_mechs[n], len(all_mechs))
 


### PR DESCRIPTION
This patch makes python-gssapi able to run on Python3, but to install it you can't use the setup script right now, because the ctypesgen module used to build the gssapi_h module is not able to run on Python3 and it generates just Python2 code.
So to install python-gssapi on Python3 follow these steps:
- Build python-gssapi on Python2.
- Look for the generated gssapi_h module in
  your/build/directory/lib/gssapi/headers/ and use 2to3 to port it to py3.
- Move the converted gssapi_h module into gssapi/source/folder/headers/.
- Finally move the gssapi source folder to
  /path/to/your/python/installation/lib/python3.x/site-packages/.
